### PR TITLE
Run docker compose test in ci

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,8 +41,6 @@ jobs:
   lint:
     name: run linters
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     steps:
       - uses: actions/checkout@v3
         with:
@@ -57,3 +55,16 @@ jobs:
         run: tox -vv --notest -e lint-py312
       - name: Run test suite
         run: tox --skip-pkg-install -e lint-py312
+  test-example:
+    name: test example using docker compose
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: docker build
+        working-directory: example
+        run: docker compose build
+      - name: run test container
+        working-directory: example
+        run: docker compose run --rm test

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:latest AS server
+FROM python:3.12.0-slim-bookworm AS base
+
+FROM base AS server
 
 RUN apt-get update \
  && apt-get install -y \
@@ -10,12 +12,12 @@ COPY example/pyproject.toml /work/
 COPY example/src /work/src
 
 RUN --mount=type=cache,target=/root/.cache \
-        python3.11 -m pip install -e .
+        python3.12 -m pip install -e .
 
 ENV PYTHONDONTWRITEBYTECODE=1
 
 
-FROM python:latest AS builder
+FROM base AS builder
 
 WORKDIR /work
 
@@ -23,16 +25,15 @@ COPY pyproject.toml README.md /work/
 COPY src /work/src
 
 RUN --mount=type=cache,target=/root/.cache \
-        python3.11 -m pip install build \
- &&     python3.11 -m build
+        python3.12 -m pip install build \
+ &&     python3.12 -m build
 
 
 FROM server AS test
 
 COPY --from=builder /work/dist/*.whl /tmp/
-RUN python3.11 -m pip install /tmp/*.whl
-
 RUN --mount=type=cache,target=/root/.cache \
-        python3.11 -m pip install \
+        python3.12 -m pip install \
+                /tmp/*.whl \
                 pytest \
                 requests

--- a/example/compose.yaml
+++ b/example/compose.yaml
@@ -20,7 +20,7 @@ services:
     environment:
       POSTGRES_PASSWORD: dbpswd
     command:
-      - python3.11
+      - python3.12
       - -m
       - example.server
     healthcheck:
@@ -42,7 +42,7 @@ services:
     environment:
       POSTGRES_PASSWORD: dbpswd
     command:
-      - python3.11
+      - python3.12
       - -m
       - pytest
       - -sqx


### PR DESCRIPTION
- Configure Github Actions to build the containers and then run the test container, all inside the `example` folder.
- Switch to python3.12 in all the docker images.
- Switch to explicit python:3.12.0-slim-bookworm base image. Using a non-explicit python:latest image (where the architecture has to be inferred on the platform was breaking in CI)