### PR TITLE
Add py38 and py39 to tox and CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,6 +20,8 @@ jobs:
           - "3.12"
           - "3.11"
           - "3.10"
+          - "3.9"
+          - "3.8"
         os:
           - ubuntu-latest
           - macos-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 description = "New approach to Python test fixtures (compatible with pytest)"
 keywords = ["tests", "testing", "fixture", "fixtures"]
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.8"
 dependencies = []
 classifiers = [
     "License :: OSI Approved :: MIT License",

--- a/src/testing/fixtures/__init__.py
+++ b/src/testing/fixtures/__init__.py
@@ -9,14 +9,15 @@ from types import TracebackType
 from typing import (
     Any,
     Callable,
-    Concatenate,
+    Dict,
     Generator,
     Generic,
     Optional,
-    ParamSpec,
+    Tuple,
     Type,
     TypeVar,
 )
+from typing_extensions import Concatenate, ParamSpec
 
 
 D = ParamSpec("D")  # Parameters injected into fixture definition
@@ -69,8 +70,8 @@ class Fixture(Generic[Y, D]):
         self._value: Y
 
         # Default values for fixture definition args and kwargs
-        self.args: tuple[Any, ...] = tuple()
-        self.kwargs: dict[str, Any] = {}
+        self.args: Tuple[Any, ...] = tuple()
+        self.kwargs: Dict[str, Any] = {}
 
         self._entries = 0  # Keep track of rentrance
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    ; py38
-    ; py39
+    py38
+    py39
     py310
     py311
     py312
@@ -32,3 +32,5 @@ python =
     3.12 = py312
     3.11 = py311
     3.10 = py310
+    3.9 = py39
+    3.8 = py38


### PR DESCRIPTION
- Use typing_extensions to pull in back-ported Concatenate and ParamSpec
- Switch to typing.Tuple and typing.Dict since py38 does not have support for using tuple and dict as types