### PR TITLE
fix: trigger for deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,11 +1,12 @@
 name: deploy
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
 
 jobs:
-  cd:
-    if: github.event_name == 'push' && github.ref == 'refs/head/main'
-
+  deploy:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Since the deploy workflow is completely separate instead of using the if syntax we can specify that the workflow is triggered "on" the "push" event filtered to the "main" branch