### PR TITLE
fix: semantic-release configuratioon

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,4 +25,9 @@ jobs:
           fetch-depth: 0
 
       - name: Build new release
-        run: semantic-release publish
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # env var expected by semantic-release
+        run: |  # configure identity for semantic-release commit
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          semantic-release publish


### PR DESCRIPTION
- semantic-release expects the github token to be present in the GH_TOKEN env var
- Configure the git user and email to belong to Github Actions so that the commit pushed by semantic-release is correctly attributed