### PR TITLE
feat: use semantic-release action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,8 +6,10 @@ on:
       - main
 
 jobs:
-  deploy:
+  release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # allow job to create Github Release
 
     steps:
 
@@ -24,10 +26,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Build new release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # env var expected by semantic-release
-        run: |  # configure identity for semantic-release commit
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          semantic-release publish
+      - name: Build distribution
+        run: |
+          python -m pip install build
+          python -m build
+
+      - name: semantic-release
+        uses: python-semantic-release/python-semantic-release@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}  # env var expected by semantic-release


### PR DESCRIPTION
- semantic-release comes with its own Github Workflow action which simplifies the setup
- add explicit build step
- rename job to release