### PR TITLE
fix: semantic-release build command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,12 +24,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
         with:
-          fetch-depth: 0
-
-      - name: Build distribution
-        run: |
-          python -m pip install build
-          python -m build
+          fetch-depth: 0  # semantic-release needs access to all previous commits
 
       - name: semantic-release
         uses: python-semantic-release/python-semantic-release@master

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ packages = ["src/testing"]
 [tool.semantic_release]
 version_variable = "pyproject.toml:version"
 branch = "main"
-build_command = "python3.12 -m build"
+build_command = "python -m build"    # In CI the interpreter is available as plain "python"
 dist_path = "dist/"
 upload_to_release = true    # auto create Github Release
 upload_to_pypi = false


### PR DESCRIPTION
- in CI (Github Action) the interpreter is available as just plain 'python'
- remove the explicit build step since semantic-release will be doing the building AFTER it has bumped the version