### PR TITLE
fix: semantic-release build-command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ packages = ["src/testing"]
 [tool.semantic_release]
 version_variable = "pyproject.toml:version"
 branch = "main"
-build_command = "python -m build"    # In CI the interpreter is available as plain "python"
+build_command = "pyproject-build"
 dist_path = "dist/"
 upload_to_release = true    # auto create Github Release
 upload_to_pypi = false


### PR DESCRIPTION
- `python -m build` is not working in CD, possibly because of a "build" folder being created
- The build package comes with a `pyproject-build` script that does the same thing so switching to that instead