### PR TITLE
feat: use default build command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ packages = ["src/testing"]
 [tool.semantic_release]
 version_variable = "pyproject.toml:version"
 branch = "main"
-build_command = "pyproject-build"
 dist_path = "dist/"
 upload_to_release = true    # auto create Github Release
 upload_to_pypi = false


### PR DESCRIPTION
the specified build commands are not working with python-semantic-release so we are going to try the default build command