### PR TITLE
fix: semantic-release config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,11 @@ only-packages = true
 packages = ["src/testing"]
 
 [tool.semantic_release]
-version_variable = "pyproject.toml:version"
+toml_version = [
+    "pyproject.toml:project.version"
+]
 branch = "main"
+build_command = "pyproject-build"
 dist_path = "dist/"
 upload_to_release = true    # auto create Github Release
 upload_to_pypi = false


### PR DESCRIPTION
misspelled config key which is being replaced with a better one re-add the build command (removing it removes the build step)