### PR TITLE
feat: use deploy ssh key

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,9 +7,9 @@ on:
 
 jobs:
   release:
+    if: github.event.commits[0].author.name != 'GitHub Actions'
+
     runs-on: ubuntu-latest
-    permissions:
-      contents: write  # allow job to create Github Release
 
     steps:
 
@@ -21,12 +21,21 @@ jobs:
       - name: Pre-requisites
         run: python -m pip install build python-semantic-release
 
+      - name: Configure Git
+        run: |
+          git config user.name "Github Actions"
+          git config user.email "<>"
+
       - name: Checkout repository
         uses: actions/checkout@v2
         with:
           fetch-depth: 0  # semantic-release needs access to all previous commits
+          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - name: Setup SSH Agent
+        uses: webfactory/ssh-agent@v0.8.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Semantic Release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: semantic-release -v version

--- a/notes.md
+++ b/notes.md
@@ -1,0 +1,62 @@
+# Notes
+
+## CI/CD
+
+The `main` branch has comprehensive branch protections which are explicitly applicable
+to Administrators as well.
+This prevents `python-semantic-release` from pushing commits to the `main` branch when
+it bumps the version (and modifies the changelog).
+
+The solution might be to use an SSH Deploy Key but that will require modifications to
+the deploy Github Action.
+
+### Create SSH key
+
+```bash
+cd ~/.ssh
+ssh-keygen -t ed25519 -a 100 -f testing-fixtures-deploy
+```
+
+*Note*: Do **not** set a passphrase.
+
+### Store keys
+
+- Add the public key as the Deploy key to the repo (Settings > Security > Deploy Keys)
+  and enable "Allow write access"
+- Add the private key as a Github Actions secret in the repo
+  (Settings > Security > Secrets and Variables > Actions)
+  under the name `SSH_PRIVATE_KEY`
+
+### Checkout code
+
+By default the checkout action uses a one-time Github token.
+Since we want to use a deploy key to push commits we need to ensure that
+the same SSH key is used to checkout the code by configuring
+the checkout action to use an `ssh-key`.
+
+### SSH Agent
+
+We want `python-semantic-release` to automatically use the SSH key when
+it pushes the new commit.
+We use the `webfactory/ssh-agent` action to setup an SSH agent with
+the private Deploy key to make it available to `semantic-release` by default.
+
+Also need to set `ignore_token_for_push = false` to force `semantic-release` to use ssh.
+
+### Avoid workflow recursion
+
+Since our release job is pushing a commit to the `main` branch there is a possibility
+of workflow recursion.
+
+Github Actions deals with this automatically **if**
+the per-workflow Github token is used.
+We are using a Deploy SSH key instead so will have to deal with recursion ourselves.
+
+To avoid that we add an `if` condition to the `release` job so that it is skipped if
+the top commit is authored by "Github Actions",
+a user which the workflow configures before it pushes a deploy commit.
+
+```yaml
+release:
+    if: github.event.commits[0].author.name != 'GitHub Actions'
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ branch = "main"
 build_command = "pyproject-build"
 dist_path = "dist/"
 upload_to_release = true    # auto create Github Release
+ignore_token_for_push = true   # use SSH (deploy key) to push
 upload_to_pypi = false
 remove_dist = false
 


### PR DESCRIPTION
the per-workflow Github token is not working because the main branch has branch protections (including for admininstrators) while the github token has the saame permissions as the user who launched the workflow