### PR TITLE
fix: configure git after checkout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,16 +21,16 @@ jobs:
       - name: Pre-requisites
         run: python -m pip install build python-semantic-release
 
-      - name: Configure Git
-        run: |
-          git config user.name "Github Actions"
-          git config user.email "<>"
-
       - name: Checkout repository
         uses: actions/checkout@v2
         with:
           fetch-depth: 0  # semantic-release needs access to all previous commits
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - name: Configure Git
+        run: |
+          git config user.name "Github Actions"
+          git config user.email "<>"
 
       - name: Setup SSH Agent
         uses: webfactory/ssh-agent@v0.8.0


### PR DESCRIPTION
it is not possible to configure git before the code has been checked out (which creates the .git folder)