### PR TITLE
fix: author of deploy commit for skipping

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    if: github.event.commits[0].author.name != 'GitHub Actions'
+    if: github.event.commits[0].author.name != 'semantic-release'
 
     runs-on: ubuntu-latest
 
@@ -26,11 +26,6 @@ jobs:
         with:
           fetch-depth: 0  # semantic-release needs access to all previous commits
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
-
-      - name: Configure Git
-        run: |
-          git config user.name "Github Actions"
-          git config user.email "<>"
 
       - name: Setup SSH Agent
         uses: webfactory/ssh-agent@v0.8.0


### PR DESCRIPTION
semantic-release creates commits with author "semantic-release" which is what we need to use for skipping workflow for the deployed commit