### PR TITLE
ci: increase semantic-release verbosity

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,4 +33,4 @@ jobs:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Semantic Release
-        run: semantic-release -v version
+        run: semantic-release -vv version


### PR DESCRIPTION
the creation of github release is failing while the new commit is being correctly pushed up increase semantic-release verbosity to figure out what is broken