### PR TITLE
fix: add debug step after semantic-release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,3 +34,6 @@ jobs:
 
       - name: Semantic Release
         run: semantic-release -vv version
+
+      - name: Debug
+        run: echo "Hello, World!"


### PR DESCRIPTION
curious to see if a step will run after the previous one fails