### PR TITLE
fix: specify github token env var

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,8 @@ jobs:
     if: github.event.commits[0].author.name != 'semantic-release'
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ branch = "main"
 build_command = "pyproject-build"
 dist_path = "dist/"
 upload_to_release = true    # auto create Github Release
+token = "GITHUB_TOKEN"
 ignore_token_for_push = true   # use SSH (deploy key) to push
 upload_to_pypi = false
 remove_dist = false


### PR DESCRIPTION
GH Action makes the per-workflow GITHUB_TOKEN available as an env var while by default semantic-release looks for GH_TOKEN since we will be using the GITHUB_TOKEN to create a new release we add write contents permission to the token