### PR TITLE
fix: gh-token in semantic-release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Semantic Release
         run: semantic-release -vv version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Debug
         run: echo "Hello, World!"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ branch = "main"
 build_command = "pyproject-build"
 dist_path = "dist/"
 upload_to_release = true    # auto create Github Release
-token = "GITHUB_TOKEN"
 ignore_token_for_push = true   # use SSH (deploy key) to push
 upload_to_pypi = false
 remove_dist = false


### PR DESCRIPTION
the per-workflow github-token is not available by default as an env var specify it explicitly using the `env` config section since we are going to be specifying it any way might as well make it available as GH_TOKEN, the default env var expected by semantic release