### PR TITLE
fix: semantic-release CLI args

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,9 +35,9 @@ jobs:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Semantic Release Commit
-        run: semantic-release -vv --no-vcs-release version
+        run: semantic-release -vv version --no-vcs-release
 
       - name: Semantic Release Github Release
-        run: semantic-release -vv --no-commit --no-changelog --no-push version
+        run: semantic-release -vv version --no-commit --no-changelog --no-push
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
fix typo in the CLI args passed to semantic-release the new args are specific to the 'version' subcommand