### PR TITLE
fix: use admin pat

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,8 @@
 name: check
 on:
   push:
+    branches:
+      - "**"  # Run on all branch pushes (and NOT tag pushes)
   pull_request:
   schedule:
     - cron: "0 2 * * *"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,17 +27,21 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0  # semantic-release needs access to all previous commits
-          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          token: ${{ secrets.PAT }}
+          # ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
-      - name: Setup SSH Agent
-        uses: webfactory/ssh-agent@v0.8.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      # - name: Setup SSH Agent
+      #   uses: webfactory/ssh-agent@v0.8.0
+      #   with:
+      #     ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Semantic Release Commit
         run: semantic-release -vv version --no-vcs-release
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
 
       - name: Semantic Release Github Release
         run: semantic-release -vv version --no-commit --no-changelog --no-push
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PAT }}
+          # GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/notes.md
+++ b/notes.md
@@ -7,7 +7,36 @@ including requiring a Pull Request.
 This prevents `python-semantic-release` from pushing commits to the `main` branch when
 it bumps the version (and modifies the changelog).
 
-The solution is to use an SSH Deploy Key but that will require modifications to
+There are a couple of possible solutions to this.
+
+## CI/CD with Personal Access Token
+
+We will create a PAT (Personal Access Token) and
+explicitly give it permission to "bypass branch protections".
+The Github Action will have to be configured to use this specific PAT instead of
+the auto-generated per-workflow Github Access Token which does **not** have
+the required permission to push commits to a protected branch.
+
+### Create Personal Access Token
+
+1. In Github nagivate to (Personal) Settings > Developer Settings >
+   Personal Access Tokens > Fine-grained tokens > Generate new token
+1. Limit repository access to just this repo.
+1. Set the following Repository Permissions:
+
+   1. Administration: Read and Write
+   1. Contents: Read and Write
+   1. Metadata: Read-only (Mandatory)
+
+1. Leave everything else set to "No Access".
+1. Click `Generate Token`
+1. Copy generated token and place it in
+   the repo's Github Actions Secrets with name `PAT`
+   (Repo Settings > Secrets and variables > Actions > New repository secret)
+
+## CI/CD with SSH Deploy Key
+
+Another solution is to use an SSH Deploy Key but that will require modifications to
 the deploy Github Action.
 
 *Note*: SSH Deploy keys use the "bypass branch protections" permission so


### PR DESCRIPTION
- Trying out the admin PAT approach where we use a PAT with Admin permissions in place of the auto-generated per-workflow Github Token
- Document this new PAT approach in the notes
- Configure the CI check to run on all branch pushes but NOT on tag push