### PR TITLE
fix: switch to using upstream semantic-release action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,27 +21,25 @@ jobs:
           python-version: 3.12
 
       - name: Pre-requisites
-        run: python -m pip install build python-semantic-release
+        run: python -m pip install build # python-semantic-release
 
       - name: Checkout repository
         uses: actions/checkout@v2
         with:
           fetch-depth: 0  # semantic-release needs access to all previous commits
           token: ${{ secrets.PAT }}
-          # ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
-      # - name: Setup SSH Agent
-      #   uses: webfactory/ssh-agent@v0.8.0
-      #   with:
-      #     ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      - name: Semantic Release
+        uses: python-semantic-release/python-semantic-release@master
+        with:
+          github_token: ${{ secrets.PAT }}
 
-      - name: Semantic Release Commit
-        run: semantic-release -vv version --no-vcs-release
-        env:
-          GH_TOKEN: ${{ secrets.PAT }}
+      # - name: Semantic Release Commit
+      #   run: semantic-release -vv version --no-vcs-release
+      #   env:
+      #     GH_TOKEN: ${{ secrets.PAT }}
 
-      - name: Semantic Release Github Release
-        run: semantic-release -vv version --no-commit --no-changelog --no-push
-        env:
-          GH_TOKEN: ${{ secrets.PAT }}
-          # GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Semantic Release Github Release
+      #   run: semantic-release -vv version --no-commit --no-changelog --no-push
+      #   env:
+      #     GH_TOKEN: ${{ secrets.PAT }}

--- a/notes.md
+++ b/notes.md
@@ -9,6 +9,13 @@ it bumps the version (and modifies the changelog).
 
 There are a couple of possible solutions to this.
 
+Unfortunately both solutions require the branch protection to **allow** admin uers
+the ability to bypass branch protections.
+To stop yourself from mistakenly pushing to the protected `main` branch from the CLI
+one can use a simple hack: `git config --global branch.main.pushRemote no_push`.
+This configures the remote for the `main` branch to the non-existent `no_push` remote.
+Trying to `git push` will cause an error because the remote cannot be found.
+
 ## CI/CD with Personal Access Token
 
 We will create a PAT (Personal Access Token) and


### PR DESCRIPTION
rather than install semantic-release and run it by hand we attempt to use the upstream python-semantic-release action