### PR TITLE
fix: disable cancel in progress

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,10 +7,6 @@ on:
   schedule:
     - cron: "0 2 * * *"
 
-concurrency:
-  group: check-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   test:
     name: test with ${{ matrix.py }} on ${{ matrix.os }}


### PR DESCRIPTION
unfortunately even though cancel-in-progress when
a new commit is pushed to a branch while the previous build is running works BUT it sends an automated email which is indicative of a failure while this should technically be considered normal/desired behavior