### PR TITLE
fix: add deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,30 +6,33 @@ on:
       - main
 
 jobs:
-  release:
-    if: github.event.commits[0].author.name != 'semantic-release'
+  test-release:
+    if: github.events.commits[0].author.name == 'semantic-release'
 
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      id-token: write
+
+    environment:
+      name: testpypi
+      url: https://pypi.org/p/testing-fixtures
 
     steps:
-
       - name: Set up Python 3.12
         uses: actions/setup-python@v2
         with:
           python-version: 3.12
 
       - name: Pre-requisites
-        run: python -m pip install build python-semantic-release
+        run: python -m pip install build
 
       - name: Checkout repository
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0  # semantic-release needs access to all previous commits
-          token: ${{ secrets.PAT }}
 
-      - name: Semantic Release Version
-        run: semantic-release version
-        env:
-          GH_TOKEN: ${{ secrets.PAT }}
+      - name: Build
+        run: pyproject-build
+
+      - name: Publish package distributions to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,33 @@
+name: version
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  version:
+    if: github.event.commits[0].author.name != 'semantic-release'
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.12
+
+      - name: Pre-requisites
+        run: python -m pip install build python-semantic-release
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # semantic-release needs access to all previous commits
+          token: ${{ secrets.PAT }}
+
+      - name: Semantic Release Version
+        run: semantic-release version
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}


### PR DESCRIPTION
- refactor old deploy to the version workflow since it was technically all about bumping the version using semantic-release
- add an actual deploy workflow which currently is publishing only to Test PyPI