### PR TITLE
fix: version bump

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: 3.12
 
       - name: Pre-requisites
-        run: python -m pip install build python-semantic-release
+        run: python -m pip install python-semantic-release
 
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -28,6 +28,6 @@ jobs:
           token: ${{ secrets.PAT }}
 
       - name: Semantic Release Version
-        run: semantic-release version
+        run: semantic-release version --skip-build
         env:
           GH_TOKEN: ${{ secrets.PAT }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,16 +43,16 @@ only-packages = true
 packages = ["src/testing"]
 
 [tool.semantic_release]
-toml_version = [
+version_toml = [
     "pyproject.toml:project.version"
 ]
 branch = "main"
-build_command = "pyproject-build"
-dist_path = "dist/"
+# build_command = "pyproject-build"
+# dist_path = "dist/"
 upload_to_release = true    # auto create Github Release
-ignore_token_for_push = true   # use SSH (deploy key) to push
-upload_to_pypi = false
-remove_dist = false
+# ignore_token_for_push = true   # use SSH (deploy key) to push
+# upload_to_pypi = false
+# remove_dist = false
 
 [tool.pylint.'MESSAGE CONTROL']
 disable = [


### PR DESCRIPTION
- fix typo in semantic-release config for specifying location of version inside the project
- Add --skip-build since semantic-release does not need to build the project to bump the version
- Remove build specific config from semantic-release