### PR TITLE
fix: use upstream semantic-release action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build
-        run: pyproject-build
+        run: python -m build
 
       - name: Publish package distributions to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -61,7 +61,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build
-        run: pyproject-build
+        run: python -m build
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -13,13 +13,13 @@ jobs:
 
     steps:
 
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.12
+      # - name: Set up Python 3.12
+      #   uses: actions/setup-python@v2
+      #   with:
+      #     python-version: 3.12
 
-      - name: Pre-requisites
-        run: python -m pip install python-semantic-release
+      # - name: Pre-requisites
+      #   run: python -m pip install python-semantic-release
 
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -27,7 +27,13 @@ jobs:
           fetch-depth: 0  # semantic-release needs access to all previous commits
           token: ${{ secrets.PAT }}
 
+      # - name: Semantic Release Version
+      #   run: semantic-release version --skip-build
+      #   env:
+      #     GH_TOKEN: ${{ secrets.PAT }}
+
       - name: Semantic Release Version
-        run: semantic-release version --skip-build
-        env:
-          GH_TOKEN: ${{ secrets.PAT }}
+        run: python-semantic-release/python-semantic-release@v8.3.0
+        with:
+          github_token: ${{ secrets.PAT }}
+          skip_build: true


### PR DESCRIPTION
fix: switch to upstream semantic-release action

    trying once again with the admin PAT and an explicit skip_build option
    since the primary problem with the upstream action was failure to build
    but we no longer need to build just to bump and release the new version

ci: refactor build command

    use the more popular `python -m build` instead of `pyproject-build`
    since they are exactly equivalent