### PR TITLE
fix: semantic-release committer name

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -13,27 +13,15 @@ jobs:
 
     steps:
 
-      # - name: Set up Python 3.12
-      #   uses: actions/setup-python@v2
-      #   with:
-      #     python-version: 3.12
-
-      # - name: Pre-requisites
-      #   run: python -m pip install python-semantic-release
-
       - name: Checkout repository
         uses: actions/checkout@v2
         with:
           fetch-depth: 0  # semantic-release needs access to all previous commits
           token: ${{ secrets.PAT }}
 
-      # - name: Semantic Release Version
-      #   run: semantic-release version --skip-build
-      #   env:
-      #     GH_TOKEN: ${{ secrets.PAT }}
-
       - name: Semantic Release Version
         uses: python-semantic-release/python-semantic-release@v8.3.0
         with:
           github_token: ${{ secrets.PAT }}
-          skip_build: true
+          git_committer_name: semantic-release
+          git_committer_email: <>


### PR DESCRIPTION
the switch to the upstream semantic-release action meant that the committer name changed from semantic-release to github-actions

we explicitly configure the action to use the former name since that is what is expected by the other publish workflow