### PR TITLE
fix: remove unnecessary fetch-depth config

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,8 +28,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       - name: Setup python for ${{ matrix.py }}
         uses: actions/setup-python@v4
         with:
@@ -47,8 +45,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - name: Setup python
         uses: actions/setup-python@v4
@@ -70,8 +66,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - name: docker build
         working-directory: example

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Set up Python 3.12
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.12
 


### PR DESCRIPTION
- the only component of CI/CD that needs access to the full commit history is the version bumping logic (sematnic-release)
- bring the setup-python actions into consistency with each other