### PR TITLE
chore: refactor tox requirements

### DIFF
--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,0 +1,3 @@
+-r requirements-test.txt
+pylint
+ruff

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,2 @@
+pytest
+mypy

--- a/tox.ini
+++ b/tox.ini
@@ -7,26 +7,25 @@ envlist =
     py312
 
 [testenv]
-deps =
-    pytest
-    mypy
+deps = -rrequirements-test.txt
 commands =
     pytest -q tests
     mypy -p testing.fixtures
     mypy tests
 
 [testenv:lint-py312]
-deps =
-    mypy
-    pylint
-    pytest
-    ruff
+deps = -rrequirements-lint.txt
 commands =
     ruff format --check .
     ruff check .
     mypy -p testing.fixtures
     mypy tests
     pylint src tests
+
+[testenv:dev-py312]
+usedevelop = true
+deps = -rrequirements-lint.txt
+commands = :
 
 [gh]
 python =


### PR DESCRIPTION
- Put the test deps in requirements-test.txt.
- Put the lint deps in requirements-lint.txt and also include requirements-test.txt in it.
- Create a new dev-py312 environment which uses an editable install. This will serve as the development environment for VS Code.