### PR TITLE
fix: Change deprecated generator.throw call

### DIFF
--- a/src/testing/fixtures/__init__.py
+++ b/src/testing/fixtures/__init__.py
@@ -218,7 +218,7 @@ class Fixture(Generic[Y, D]):
             # tell if we get the same exception back
             value = typ()
         try:
-            self._generator.throw(typ, value, traceback)
+            self._generator.throw(value)
         except StopIteration as exc:
             # Suppress StopIteration *unless* it's the same exception that
             # was passed to throw().  This prevents a StopIteration


### PR DESCRIPTION
The method now expects only the exception value (and not its type and traceback as well).